### PR TITLE
Add release drafer

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,77 @@
+name-template: 'Release v$NEXT_PATCH_VERSION'
+tag-template: "$RESOLVED_VERSION"
+change-template: "- #$NUMBER $TITLE @$AUTHOR"
+sort-direction: ascending
+
+categories:
+  - title: "🚨 Major Release 🚨"
+    labels:
+      - "major-change"
+  - title: "🚨 Breaking changes"
+    labels:
+      - "breaking-change"
+  - title: "✨ New features"
+    labels:
+      - "new-feature"
+  - title: "🐛 Bug fixes"
+    labels:
+      - "bugfix"
+  - title: "🚀 Enhancements"
+    labels:
+      - "enhancement"
+      - "refactor"
+      - "performance"
+  - title: "🧰 Maintenance"
+    labels:
+      - "maintenance"
+      - "ci"
+  - title: "📚 Documentation"
+    labels:
+      - "documentation"
+  - title: "⬆️ Dependency updates"
+    collapse-after: 5
+    labels:
+      - "dependencies"
+  - title: "🚨🚨 Security Fixes 🚨🚨"
+    labels:
+      - "security"
+
+exclude-labels:
+  - "sync"
+
+version-resolver:
+  major:
+    labels:
+      - "major-change"
+      - "breaking-change"
+  minor:
+    labels:
+      - "minor"
+      - "new-feature"
+  patch:
+    labels:
+      - "bugfix"
+      - "chore"
+      - "ci"
+      - "dependencies"
+      - "documentation"
+      - "enhancement"
+      - "performance"
+      - "refactor"
+      - "security"
+  default: patch
+no-changes-template: '- No changes'
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/scns/Windows-Update-Report-MultiTenan/compare/$PREVIOUS_TAG...$RESOLVED_VERSION
+
+   _To receive a notification on new releases, click on **Watch** > **Custom** > **Releases** on the top._
+
+   _Be sure to 🌟 this repository for updates! Its a hobby project . Flash it go to the link https://scns.github.io/Windows-Update-Report-MultiTenan/._
+
+  ## Contributors
+
+  $CONTRIBUTORS

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,10 @@
+
 # Windows Update Report MultiTenant
+
+| Repository Status | Windows Update Report Repo |
+| :--- | :--- |
+|  [![last commit time][github-last-commit]][github-master] [![GitHub Activity][commits-shield]][commits] | |
+| [![License][license-shield]](LICENSE) [![Forks][forks-shield]][forks-url] [![Stargazers][stars-shield]][stars-url] [![Issues][issues-shield]][issues-url] | [![Contributors][contributors-shield]][contributors-url] [![GitHub release](https://img.shields.io/github/release/scns/Windows-Update-Report-MultiTenant.svg)](https://GitHub.com/scns/Windows-Update-Report-MultiTenant/releases)
 
 ![Dashboard voorbeeld](images/001.png)
 
@@ -77,3 +83,17 @@ Install-Module Microsoft.Graph -Scope CurrentUser
 ---
 
 © 2025 by Maarten Schmeitz
+
+[commits-shield]: https://img.shields.io/github/commit-activity/m/scns/Windows-Update-Report-MultiTenant.svg
+[commits]: https://github.com/scns/Windows-Update-Report-MultiTenant/commits/main
+[github-last-commit]: https://img.shields.io/github/last-commit/scns/Windows-Update-Report-MultiTenant.svg?style=plasticr
+[github-master]: https://github.com/scns/Windows-Update-Report-MultiTenant/commits/main
+[license-shield]: https://img.shields.io/github/license/scns/Windows-Update-Report-MultiTenant.svg
+[contributors-url]: https://github.com/scns/Windows-Update-Report-MultiTenant/graphs/contributors
+[contributors-shield]: https://img.shields.io/github/contributors/scns/Windows-Update-Report-MultiTenant.svg
+[forks-shield]: https://img.shields.io/github/forks/scns/Windows-Update-Report-MultiTenant.svg
+[forks-url]: https://github.com/scns/Windows-Update-Report-MultiTenant/network/members
+[stars-shield]: https://img.shields.io/github/stars/scns/Windows-Update-Report-MultiTenant.svg
+[stars-url]: https://github.com/scns/Windows-Update-Report-MultiTenant/stargazers
+[issues-shield]: https://img.shields.io/github/issues/scns/Windows-Update-Report-MultiTenant.svg
+[issues-url]: https://github.com/scns/Windows-Update-Report-MultiTenant/issues

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 
 # Windows Update Report MultiTenant
 
-| Repository Status | Windows Update Report Repo |
+| Repository Status | Windows Update Report |
 | :--- | :--- |
 |  [![last commit time][github-last-commit]][github-master] [![GitHub Activity][commits-shield]][commits] | |
 | [![License][license-shield]](LICENSE) [![Forks][forks-shield]][forks-url] [![Stargazers][stars-shield]][stars-url] [![Issues][issues-shield]][issues-url] | [![Contributors][contributors-shield]][contributors-url] [![GitHub release](https://img.shields.io/github/release/scns/Windows-Update-Report-MultiTenant.svg)](https://GitHub.com/scns/Windows-Update-Report-MultiTenant/releases)


### PR DESCRIPTION
This pull request introduces a release automation configuration and enhances the `readme.md` file with repository status badges and additional links. These changes improve release management and provide better visibility into the repository's status and activity.

### Release Automation:
* Added a `.github/release-drafter.yml` file to automate release notes generation. It includes templates for release names, tags, and categorized change summaries, as well as contributor acknowledgments. Labels are mapped to semantic versioning rules for version resolution.

### Documentation Updates:
* Enhanced `readme.md` by adding badges for repository status, activity, license, forks, stars, issues, and contributors. These badges provide quick insights into the repository's metrics and encourage user engagement.
* Appended markdown references in `readme.md` to support the newly added badges, linking them to the appropriate GitHub resources.