### PR TITLE
Enhance HTML report generation with customer tab counts and improve w…

### DIFF
--- a/get-windows-update-report.ps1
+++ b/get-windows-update-report.ps1
@@ -291,10 +291,12 @@ $CustomerTabs = ""
 $CustomerTables = ""
 foreach ($Customer in $LatestCsvPerCustomer.Keys) {
     $TableRows = ""
+    $RowCount = 0
     foreach ($row in $LatestCsvPerCustomer[$Customer]) {
         $TableRows += "<tr><td>$($row.Device)</td><td>$($row.'Missing Updates')</td><td>$($row.Count)</td><td>$($row.LastSeen)</td><td>$($row.LoggedOnUsers)</td></tr>`n"
+        $RowCount++
     }
-    $CustomerTabs += "<button class='tablinks' onclick=""openCustomer(event, '$Customer')"">$Customer</button>"
+    $CustomerTabs += '<button class="tablinks" onclick="openCustomer(event, ''' + $Customer + ''')">' + $Customer + ' (' + $RowCount + ')</button>'
     $CustomerTables += @"
     <div id="$Customer" class="tabcontent" style="display:none">
         <h2>Laatste overzicht voor $Customer ($($LatestDatePerCustomer[$Customer]))</h2>
@@ -429,7 +431,7 @@ try {
     }
     else {
         Write-Warning "Het HTML rapportbestand bestaat niet: $HtmlPath"
-        Write-Host "U kunt het rapport handmatig openen via: $HtmlPath" -ForegroundColor Yellow
+        Write-host "U kunt het rapport handmatig openen via: $HtmlPath" -ForegroundColor Yellow
     }
 }
 catch {


### PR DESCRIPTION
This pull request introduces a minor improvement to the customer tab display in the Windows Update report, making it easier to see how many devices are listed per customer. It also makes a small stylistic adjustment to the output message.

Enhancements to report usability:

* The customer tab buttons in the HTML report now display the number of devices for each customer, making it easier to see device counts at a glance. (`get-windows-update-report.ps1`)

Stylistic consistency:

* Standardized the casing of the `Write-Host` command for consistency in the output message when the HTML report file does not exist. (`get-windows-update-report.ps1`)