### PR TITLE
Sort customer keys for chart data and latest CSV generation

### DIFF
--- a/get-windows-update-report.ps1
+++ b/get-windows-update-report.ps1
@@ -269,7 +269,7 @@ foreach ($file in $OverviewFiles) {
 $ChartDatasets = ""
 $ChartLabels = @()
 $ChartDataJSON = "{"
-foreach ($Customer in $CountsPerDayPerCustomer.Keys) {
+foreach ($Customer in ($CountsPerDayPerCustomer.Keys | Sort-Object)) {
     $Data = ($CountsPerDayPerCustomer[$Customer] | ForEach-Object { $_.TotalCount }) -join ","
     $Labels = ($CountsPerDayPerCustomer[$Customer] | ForEach-Object { "'$($_.Date)'" })
     if ($Labels.Count -gt $ChartLabels.Count) { $ChartLabels = $Labels }
@@ -300,7 +300,7 @@ $ChartLabelsString = $ChartLabels -join ","
 # Genereer tabbladen en tabellen voor alleen de laatste datum per klant
 $CustomerTabs = ""
 $CustomerTables = ""
-foreach ($Customer in $LatestCsvPerCustomer.Keys) {
+foreach ($Customer in ($LatestCsvPerCustomer.Keys | Sort-Object)) {
     $TableRows = ""
     $RowCount = 0
     foreach ($row in $LatestCsvPerCustomer[$Customer]) {


### PR DESCRIPTION
This pull request makes small improvements to the ordering of customer-related data in the `get-windows-update-report.ps1` script. The changes ensure that customer information is processed in a consistent, sorted order.

* Chart data generation: Modified the loop to sort customer keys when generating chart datasets and labels.
* Customer tabs and tables: Changed the iteration to sort customer keys when creating tabs and tables for the latest data per customer.