### PR TITLE
Add y-axis scaling to chart for improved data visualization

### DIFF
--- a/get-windows-update-report.ps1
+++ b/get-windows-update-report.ps1
@@ -420,6 +420,11 @@ $Html = @"
                     display: true,
                     text: 'Alle klanten'
                 }
+            },
+            scales: {
+                y: {
+                    beginAtZero: true
+                }
             }
         }
     });


### PR DESCRIPTION
This pull request adds a configuration to the chart rendering in `get-windows-update-report.ps1` to ensure the y-axis always starts at zero, which improves the clarity of the chart visualization.

* Chart configuration: Added the `scales.y.beginAtZero: true` setting to the chart options, ensuring the y-axis starts at zero for better readability.