### PR TITLE
Enhance release drafter configuration by adding file-specific autolab…

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,35 @@
-name-template: 'Release v$NEXT_PATCH_VERSION'
-tag-template: "$RESOLVED_VERSION"
+name-template: 'Release v$RESOLVED_VERSION'
+tag-template: "v$RESOLVED_VERSION"
 change-template: "- #$NUMBER $TITLE @$AUTHOR"
 sort-direction: ascending
+
+autolabeler:
+  - label: 'documentation'
+    files:
+      - '*.md'
+      - 'docs/**/*'
+  - label: 'dependencies'
+    files:
+      - '.github/dependabot.yml'
+      - '.github/workflows/*'
+  - label: 'ci'
+    files:
+      - '.github/workflows/*'
+      - '.github/release-drafter.yml'
+  - label: 'enhancement'
+    title:
+      - '/enhance/i'
+      - '/improve/i'
+      - '/add/i'
+  - label: 'bugfix'
+    title:
+      - '/fix/i'
+      - '/bug/i'
+      - '/resolve/i'
+  - label: 'new-feature'
+    title:
+      - '/feature/i'
+      - '/new/i'
 
 categories:
   - title: "🚨 Major Release 🚨"
@@ -38,16 +66,20 @@ categories:
 
 exclude-labels:
   - "sync"
+  - "skip-changelog"
 
 version-resolver:
   major:
     labels:
       - "major-change"
       - "breaking-change"
+      - "type: major"
   minor:
     labels:
       - "minor"
       - "new-feature"
+      - "type: minor"
+      - "enhancement"
   patch:
     labels:
       - "bugfix"
@@ -55,10 +87,11 @@ version-resolver:
       - "ci"
       - "dependencies"
       - "documentation"
-      - "enhancement"
       - "performance"
       - "refactor"
       - "security"
+      - "type: patch"
+      - "maintenance"
   default: patch
 
 no-changes-template: '- No changes'

--- a/.github/workflows/drafter.yaml
+++ b/.github/workflows/drafter.yaml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
This pull request updates the release management configuration to improve automation and labeling in GitHub workflows. The main changes include enhanced autolabeling for PRs, refined versioning templates, and improved workflow triggers for release drafts.

Release workflow and labeling improvements:

* Added an `autolabeler` section to `.github/release-drafter.yml` to automatically apply labels (such as `documentation`, `dependencies`, `ci`, `enhancement`, `bugfix`, and `new-feature`) based on file paths and PR titles.
* Updated `name-template` and `tag-template` in `.github/release-drafter.yml` to use `$RESOLVED_VERSION` for consistency and clarity in release naming and tagging.
* Refined version resolver label mappings in `.github/release-drafter.yml`, including new label types (`type: major`, `type: minor`, `type: patch`, `maintenance`) and moving `enhancement` from patch to minor, for more accurate semantic versioning.
* Added `skip-changelog` to `exclude-labels` in `.github/release-drafter.yml` to prevent certain PRs from appearing in changelogs.

Workflow automation:

* Updated `.github/workflows/drafter.yaml` to trigger the release drafter workflow on pull request events (`opened`, `reopened`, `synchronize`) in addition to pushes to `main`, ensuring release drafts stay up-to-date with PR activity.