### PR TITLE
Add auto-assign configuration for reviewers and assignees in GitHub w…

### DIFF
--- a/.github/auto-assign.yml
+++ b/.github/auto-assign.yml
@@ -1,0 +1,26 @@
+# Configuratie voor automatische toewijzing van reviewers en assignees
+addReviewers: true
+addAssignees: true
+
+# Reviewers die automatisch worden toegevoegd aan elke PR
+reviewers:
+  - scns
+
+# Assignees die automatisch worden toegevoegd aan elke PR en Issue
+assignees:
+  - scns
+
+# Optionele instellingen
+skipKeywords:
+  - wip
+  - draft
+  - "[skip assign]"
+  - "discussion"
+
+# Aantal reviewers/assignees dat wordt toegevoegd
+numberOfReviewers: 1
+numberOfAssignees: 1
+
+# Issue-specifieke instellingen
+addAssigneesToIssues: true
+skipDraftIssues: true

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,23 @@
+---
+name: Auto Assign
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  issues:
+    types: [opened, reopened]
+
+jobs:
+  auto-assign:
+    name: 🔄 Auto assign PR/Issue
+    runs-on: ubuntu-latest
+    if: github.actor != 'scns'  # Voorkom auto-assign als scns zelf de PR/Issue opent
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
+    steps:
+      - name: 👤 Auto assign reviewer and assignee
+        uses: kentaro-m/auto-assign-action@v2.0.0
+        with:
+          configuration-path: '.github/auto-assign.yml'


### PR DESCRIPTION
This pull request introduces automated assignment of reviewers and assignees to pull requests and issues using GitHub Actions. The main changes include adding configuration and workflow files to enable and customize this automation.

**Automation setup:**

* Added `.github/auto-assign.yml` to configure automatic assignment, specifying `scns` as both reviewer and assignee, setting assignment rules, and including skip keywords to prevent assignment for drafts or work-in-progress items.
* Added `.github/workflows/auto-assign.yml` to set up a GitHub Action that triggers on PR and issue events, runs the auto-assign action, and uses the configuration file, while skipping assignment if the author is `scns`.