### PR TITLE
Enhance HTML report generation: add auto-open feature and update conf…

### DIFF
--- a/_config.json
+++ b/_config.json
@@ -2,5 +2,6 @@
     "exportRetentionCount": 40,
     "cleanupOldExports": true,
     "exportDirectory": "exports",
-    "archiveDirectory": "archive"
+    "archiveDirectory": "archive",
+    "autoOpenHtmlReport": true
 }

--- a/get-windows-update-report.ps1
+++ b/get-windows-update-report.ps1
@@ -580,23 +580,30 @@ $Html = @"
 $HtmlPath = ".\$($config.exportDirectory)\Windows_Update_Overview.html"
 Set-Content -Path $HtmlPath -Value $Html -Encoding UTF8
 
-# Open het HTML bestand automatisch in de standaard webbrowser
+# Open het HTML bestand automatisch in de standaard webbrowser (indien geconfigureerd)
 Write-Host "HTML rapport gegenereerd: $HtmlPath" -ForegroundColor Green
-Write-Host "Openen van rapport in standaard webbrowser..." -ForegroundColor Cyan
-try {
-    if ((Test-Path $HtmlPath -PathType Leaf) -and ($HtmlPath.ToLower().EndsWith(".html")))
-    {
-        Start-Process $HtmlPath
-        Write-Host "Rapport succesvol geopend in webbrowser." -ForegroundColor Green
+
+if ($config.autoOpenHtmlReport -eq $true) {
+    Write-Host "Openen van rapport in standaard webbrowser..." -ForegroundColor Cyan
+    try {
+        if ((Test-Path $HtmlPath -PathType Leaf) -and ($HtmlPath.ToLower().EndsWith(".html")))
+        {
+            Start-Process $HtmlPath
+            Write-Host "Rapport succesvol geopend in webbrowser." -ForegroundColor Green
+        }
+        else {
+            Write-Warning "Het HTML rapportbestand bestaat niet: $HtmlPath"
+            Write-Host "U kunt het rapport handmatig openen via: $HtmlPath" -ForegroundColor Yellow
+        }
     }
-    else {
-        Write-Warning "Het HTML rapportbestand bestaat niet: $HtmlPath"
-        Write-host "U kunt het rapport handmatig openen via: $HtmlPath" -ForegroundColor Yellow
+    catch {
+        Write-Warning "Kon het rapport niet automatisch openen: $($_.Exception.Message)"
+        Write-Host "U kunt het rapport handmatig openen via: $HtmlPath" -ForegroundColor Yellow
     }
 }
-catch {
-    Write-Warning "Kon het rapport niet automatisch openen: $($_.Exception.Message)"
-    Write-Host "U kunt het rapport handmatig openen via: $HtmlPath" -ForegroundColor Yellow
+else {
+    Write-Host "Automatisch openen van rapport is uitgeschakeld in configuratie." -ForegroundColor Yellow
+    Write-Host "U kunt het rapport handmatig openen via: $HtmlPath" -ForegroundColor Cyan
 }
 
 Write-Host "`nScript voltooid! Alle rapporten zijn gegenereerd en beschikbaar in de exports directory." -ForegroundColor Green


### PR DESCRIPTION
This pull request adds a new configuration option to control whether the generated HTML report is automatically opened in the default web browser. The script now checks the `autoOpenHtmlReport` setting from `_config.json` and adjusts its behavior accordingly, improving flexibility for users who may not want the report to open automatically.

Configuration changes:

* Added `autoOpenHtmlReport` boolean option to `_config.json` to enable or disable automatic opening of the HTML report after generation.

Script logic updates:

* Updated `get-windows-update-report.ps1` to check the `autoOpenHtmlReport` setting before attempting to open the HTML report, and provide appropriate messages based on the configuration. [[1]](diffhunk://#diff-85f20a91d0c3da29186b724aac5d0c4e77b0307ad8a31f404e2e02cd629295d0L583-R586) [[2]](diffhunk://#diff-85f20a91d0c3da29186b724aac5d0c4e77b0307ad8a31f404e2e02cd629295d0L594-R607)