### PR TITLE
Add lastSeenDaysFilter configuration option

### DIFF
--- a/CONFIG-UITLEG.md
+++ b/CONFIG-UITLEG.md
@@ -51,6 +51,17 @@ Dit bestand legt uit wat elke instelling in `config.json` doet.
   - `true`: Het HTML-rapport wordt automatisch geopend in de standaard webbrowser
   - `false`: Het HTML-rapport wordt niet automatisch geopend (handig voor server omgevingen of geautomatiseerde runs)
 
+
+### `lastSeenDaysFilter`
+
+- **Type**: Number
+- **Standaard**: 0
+- **Beschrijving**: Filtert de rapportage (tabel én grafiek) op basis van het aantal dagen sinds een device voor het laatst gezien is.
+  - `0`: Alle devices worden weergegeven
+  - `>0`: Alleen devices die in de laatste N dagen zijn gezien worden getoond
+
+Deze filtering is zichtbaar in zowel de tabellen als de grafieken in het HTML-dashboard.
+
 ## Voorbeeld Configuratie
 
 ```json
@@ -59,7 +70,8 @@ Dit bestand legt uit wat elke instelling in `config.json` doet.
     "cleanupOldExports": true,
     "exportDirectory": "exports",
     "archiveDirectory": "archive",
-    "autoOpenHtmlReport": true
+    "autoOpenHtmlReport": true,
+    "lastSeenDaysFilter": 0
 }
 ```
 
@@ -70,3 +82,4 @@ Met deze instellingen:
 - Nieuwe exports gaan naar de "exports" directory
 - Gearchiveerde bestanden gaan naar de "archive" directory
 - Het HTML-rapport wordt automatisch geopend in de webbrowser
+- De rapportage wordt gefilterd op basis van het aantal dagen sinds een device voor het laatst gezien is (indien ingesteld)

--- a/_config.json
+++ b/_config.json
@@ -3,5 +3,6 @@
     "cleanupOldExports": true,
     "exportDirectory": "exports",
     "archiveDirectory": "archive",
-    "autoOpenHtmlReport": true
+    "autoOpenHtmlReport": true,
+    "lastSeenDaysFilter": 0
 }

--- a/readme.md
+++ b/readme.md
@@ -84,13 +84,15 @@ Het `credentials.json` bestand heeft het volgende format:
 
 Het `config.json` bestand bevat alle instellingen:
 
+
 ```json
 {
-    "exportRetentionCount": 40,
-    "cleanupOldExports": true,
-    "exportDirectory": "exports",
-    "archiveDirectory": "archive",
-    "autoOpenHtmlReport": true
+  "exportRetentionCount": 40,
+  "cleanupOldExports": true,
+  "exportDirectory": "exports",
+  "archiveDirectory": "archive",
+  "autoOpenHtmlReport": true,
+  "lastSeenDaysFilter": 0
 }
 ```
 
@@ -101,6 +103,7 @@ Het `config.json` bestand bevat alle instellingen:
 - `exportDirectory`: Directory waar nieuwe export bestanden worden opgeslagen
 - `archiveDirectory`: Directory waar oude export bestanden worden gearchiveerd
 - `autoOpenHtmlReport`: Automatisch openen van HTML-rapport in webbrowser (true/false)
+- `lastseenDaysFilter` : Filtert de rapportage (tabel én grafiek) op basis van het aantal dagen sinds een device voor het laatst gezien is.
 
 > 📖 **Gedetailleerde configuratie uitleg**: Voor uitgebreide informatie over elke configuratie optie, zie [CONFIG-UITLEG.md](CONFIG-UITLEG.md)
 


### PR DESCRIPTION
Introduce a configuration option to filter reports based on the last seen date of devices, enhancing the ability to customize data visibility in the HTML dashboard. Update documentation to reflect this new feature.