### PR TITLE
Add last seen machines information to customer overview

### DIFF
--- a/get-windows-update-report.ps1
+++ b/get-windows-update-report.ps1
@@ -448,9 +448,11 @@ foreach ($Customer in ($LatestCsvPerCustomer.Keys | Sort-Object)) {
         }
     }
     $CustomerTabs += '<button class="tablinks" onclick="openCustomer(event, ''' + $Customer + ''')">' + $Customer + ' (' + $RowCount + ')</button>'
+    $lastSeenText = ($filterDays -eq 0) ? 'Dit zijn alle machines die gevonden kunnen worden.' : "Deze machines zijn de laatste $filterDays dagen online geweest.";
     $CustomerTables += @"
     <div id="$Customer" class="tabcontent" style="display:none">
         <h2>Laatste overzicht voor $Customer ($($LatestDatePerCustomer[$Customer]))</h2>
+        <p style='font-style:italic;color:#555;'>$lastSeenText</p>
         <button onclick="exportTableToCSV('overviewTable_$Customer', '$Customer-full.csv', false)">Exporteren volledige tabel</button>
         <button onclick="exportTableToCSV('overviewTable_$Customer', '$Customer-filtered.csv', true)">Exporteren gefilterde rijen</button>
         <table id="overviewTable_$Customer" class="display" style="width:100%">


### PR DESCRIPTION
This pull request adds a small enhancement to the customer overview section in the `get-windows-update-report.ps1` script. Now, each customer tab displays a contextual note about the machines listed, clarifying whether all machines are shown or only those seen online in the past specified number of days. 

* User experience improvement:
  * Added a descriptive message (`$lastSeenText`) above the customer table to indicate if the list includes all machines or only those online in the last `$filterDays` days.