### PR TITLE
Fix Full Changelog URL format in release drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -101,7 +101,7 @@ template: |
 
   $CHANGES
 
-  **Full Changelog**: https://github.com/scns/Windows-Update-Report-MultiTenant/compare/$PREVIOUS_TAG...$RESOLVED_VERSION
+  **Full Changelog**: https://github.com/scns/Windows-Update-Report-MultiTenant/compare/v$PREVIOUS_TAG...v$RESOLVED_VERSION
 
   _To receive a notification on new releases, click on **Watch** > **Custom** > **Releases** on the top._
 


### PR DESCRIPTION
This pull request updates the release notes template in `.github/release-drafter.yml` to ensure that changelog links use the correct tag format.

Release notes template update:

* Changed the changelog URL to use `v$PREVIOUS_TAG` and `v$RESOLVED_VERSION` instead of the previous variables, ensuring consistency with tag naming conventions.