### PR TITLE
Fix Full Changelog URL format in release drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -101,7 +101,7 @@ template: |
 
   $CHANGES
 
-  **Full Changelog**: https://github.com/scns/Windows-Update-Report-MultiTenant/compare/v$PREVIOUS_TAG...v$RESOLVED_VERSION
+  **Full Changelog**: https://github.com/scns/Windows-Update-Report-MultiTenant/compare/$PREVIOUS_TAG...$RESOLVED_VERSION
 
   _To receive a notification on new releases, click on **Watch** > **Custom** > **Releases** on the top._
 


### PR DESCRIPTION
This pull request contains a minor update to the release notes template in `.github/release-drafter.yml`. The change corrects the formatting of the changelog URL by removing unnecessary "v" prefixes from the `$PREVIOUS_TAG` and `$RESOLVED_VERSION` variables.