### PR TITLE
[FR] Static Colors for the graph per customer

### DIFF
--- a/_credentials.json
+++ b/_credentials.json
@@ -1,6 +1,6 @@
 {
 "LoginCredentials":[
-    {"customername":"Customer1", "ClientID": "[Your Client/App ID]", "Secret":"[Your App Secret]", "TenantID": "[Your Tenant ID]"},
-    {"customername":"Customer2", "ClientID": "[Your Client/App ID]", "Secret":"[Your App Secret]", "TenantID": "[Your Tenant ID]"}
+    {"customername":"Customer1", "ClientID": "[Your Client/App ID]", "Secret":"[Your App Secret]", "TenantID": "[Your Tenant ID]", "color": "#1f77b4"},
+    {"customername":"Customer2", "ClientID": "[Your Client/App ID]", "Secret":"[Your App Secret]", "TenantID": "[Your Tenant ID]", "color": "#ff7f0e"}
 ]
 }

--- a/get-windows-update-report.ps1
+++ b/get-windows-update-report.ps1
@@ -371,29 +371,32 @@ foreach ($Customer in ($CountsPerDayPerCustomer.Keys | Sort-Object)) {
     $CountData = $CountDataArray -join ","
     $ClientData = $ClientDataArray -join ","
     
-    $BaseColor = "$(Get-Random -Minimum 0 -Maximum 255),$(Get-Random -Minimum 0 -Maximum 255),$(Get-Random -Minimum 0 -Maximum 255)"
-    
+    $credObj = $data.LoginCredentials | Where-Object { $_.customername -eq $Customer }
+    $HexColor = $credObj.color
+    # Fallback: als geen kleur, gebruik blauw
+    if (-not $HexColor) { $HexColor = '#1f77b4' }
+
     # Dataset 1: Updates (volle lijn)
     $ChartDatasets += @"
         {
             label: '$Customer - Updates',
             data: [$CountData],
-            borderColor: 'rgb($BaseColor)',
-            backgroundColor: 'rgb($BaseColor)',
+            borderColor: '$HexColor',
+            backgroundColor: '$HexColor',
             fill: false,
             tension: 0.2,
             spanGaps: true,
             borderWidth: 2
         },
 "@
-    
+
     # Dataset 2: Clients (gestippelde lijn)
     $ChartDatasets += @"
         {
             label: '$Customer - Clients',
             data: [$ClientData],
-            borderColor: 'rgba($BaseColor, 0.6)',
-            backgroundColor: 'rgba($BaseColor, 0.6)',
+            borderColor: '$HexColor',
+            backgroundColor: '$HexColor',
             fill: false,
             tension: 0.2,
             spanGaps: true,
@@ -401,19 +404,19 @@ foreach ($Customer in ($CountsPerDayPerCustomer.Keys | Sort-Object)) {
             borderDash: [5, 5]
         },
 "@
-    
+
     # Voeg data toe voor individuele klant grafieken
     $CustomerLabels = ($CountsPerDayPerCustomer[$Customer] | ForEach-Object { "'$($_.Date)'" })
     $CustomerCountData = ($CountsPerDayPerCustomer[$Customer] | ForEach-Object { $_.TotalCount }) -join ","
     $CustomerClientData = ($ClientsPerDayPerCustomer[$Customer] | ForEach-Object { $_.ClientCount }) -join ","
-    
+
     $ChartDataJSON += @"
     '$Customer': {
         labels: [$($CustomerLabels -join ",")],
         countData: [$CustomerCountData],
         clientData: [$CustomerClientData],
-        borderColor: 'rgb($BaseColor)',
-        backgroundColor: 'rgb($BaseColor)'
+        borderColor: '$HexColor',
+        backgroundColor: '$HexColor'
     },
 "@
 }

--- a/readme.md
+++ b/readme.md
@@ -63,12 +63,15 @@ Het `credentials.json` bestand heeft het volgende format:
       "ClientID": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
       "Secret": "YOUR-CLIENT-SECRET",
       "TenantID": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-      "customername": "KlantNaam"
+      "customername": "KlantNaam",
+      "color": "#1f77b4"
     }
     // Voeg meer tenants toe indien nodig
   ]
 }
 ```
+
+**color**: Geef per klant een vaste HTML kleurcode op (hex, bijvoorbeeld `#1f77b4`). Deze kleur wordt gebruikt in de grafieken van het HTML-dashboard.
 
 #### Configuratie bestand
 


### PR DESCRIPTION
This pull request introduces a way to specify a fixed color for each customer in the `credentials.json` file, which is then used to consistently color that customer's data in the generated HTML dashboard graphs. This improves the clarity and consistency of the dashboard visualizations by ensuring that each customer always has the same color across reports.

**Credentials and Configuration Updates:**

* Added a new `color` property (hex color code) for each customer in the `LoginCredentials` array of `_credentials.json`, allowing for consistent color assignment in dashboard charts.
* Updated the documentation in `readme.md` to describe the new `color` field and its usage, including an example and explanation.

**Dashboard Visualization Improvements:**

* Modified `get-windows-update-report.ps1` to read the `color` property from credentials and use it for chart dataset colors, falling back to blue (`#1f77b4`) if not specified.
* Updated chart dataset definitions in `get-windows-update-report.ps1` to use the customer's hex color for both border and background colors, replacing the previous random color generation. [[1]](diffhunk://#diff-85f20a91d0c3da29186b724aac5d0c4e77b0307ad8a31f404e2e02cd629295d0L395-R399) [[2]](diffhunk://#diff-85f20a91d0c3da29186b724aac5d0c4e77b0307ad8a31f404e2e02cd629295d0L415-R419)