### PR TITLE
Update footer to include project version in the report

### DIFF
--- a/get-windows-update-report.ps1
+++ b/get-windows-update-report.ps1
@@ -22,16 +22,17 @@ De resultaten worden geëxporteerd naar CSV-bestanden en een HTML-dashboard met 
 Maarten Schmeitz (info@maarten-schmeitz.nl  | https://www.mrtn.blog)
 
 .LASTEDIT
-2025-08-05
+2025-08-13
 
 .VERSIE
-2.0
+3.0
 #>
 
-# Import configuratie
-    $ProjectVersion = "2.0"
-    $LastEditDate = "2025-08-05"
+#Versie-informatie
+    $ProjectVersion = "3.0"
+    $LastEditDate = "2025-08-13"
 
+# Import configuratie
     try {
     $configJson = Get-Content -Path ".\config.json" -Raw
     $config = $configJson | ConvertFrom-Json

--- a/get-windows-update-report.ps1
+++ b/get-windows-update-report.ps1
@@ -29,6 +29,7 @@ Maarten Schmeitz (info@maarten-schmeitz.nl  | https://www.mrtn.blog)
 #>
 
 # Import configuratie
+    $ProjectVersion = "2.0"
 try {
     $configJson = Get-Content -Path ".\config.json" -Raw
     $config = $configJson | ConvertFrom-Json
@@ -609,7 +610,7 @@ $Html = @"
     $CustomerTables
     
     <div class="footer">
-        Powered by <a href="https://github.com/scns/Windows-Update-Report-MultiTenant" target="_blank">Windows Update MultiTenant</a> by  <a href="https://mrtn.blog" target="_blank">Maarten Schmeitz (mrtn.blog)</a>
+    Powered by <a href="https://github.com/scns/Windows-Update-Report-MultiTenant" target="_blank">Windows Update MultiTenant</a> <span style="font-weight:normal;color:#888;">v$ProjectVersion</span> by  <a href="https://mrtn.blog" target="_blank">Maarten Schmeitz (mrtn.blog)</a>
     </div>
 </div>
 <script>

--- a/get-windows-update-report.ps1
+++ b/get-windows-update-report.ps1
@@ -30,7 +30,9 @@ Maarten Schmeitz (info@maarten-schmeitz.nl  | https://www.mrtn.blog)
 
 # Import configuratie
     $ProjectVersion = "2.0"
-try {
+    $LastEditDate = "2025-08-05"
+
+    try {
     $configJson = Get-Content -Path ".\config.json" -Raw
     $config = $configJson | ConvertFrom-Json
 }
@@ -610,7 +612,7 @@ $Html = @"
     $CustomerTables
     
     <div class="footer">
-    Powered by <a href="https://github.com/scns/Windows-Update-Report-MultiTenant" target="_blank">Windows Update MultiTenant</a> <span style="font-weight:normal;color:#888;">v$ProjectVersion</span> by  <a href="https://mrtn.blog" target="_blank">Maarten Schmeitz (mrtn.blog)</a>
+    Powered by <a href="https://github.com/scns/Windows-Update-Report-MultiTenant" target="_blank">Windows Update MultiTenant</a> <span style="font-weight:normal;color:#888;">v$ProjectVersion $LastEditDate</span> by  <a href="https://mrtn.blog" target="_blank">Maarten Schmeitz (mrtn.blog)</a>
     </div>
 </div>
 <script>


### PR DESCRIPTION
This pull request updates versioning information and improves the HTML dashboard footer in the `get-windows-update-report.ps1` script. The main changes are focused on keeping the version and last edit date consistent and visible in the exported dashboard.

Versioning and metadata updates:

* Updated the version number and last edit date in the script comments and added variables `$ProjectVersion` and `$LastEditDate` for centralized version management.

Dashboard footer improvements:

* Modified the HTML dashboard footer to dynamically display the current version and last edit date using the new variables, improving transparency for users.