### PR TITLE
Refactor last seen text assignment for clarity in report generation

### DIFF
--- a/get-windows-update-report.ps1
+++ b/get-windows-update-report.ps1
@@ -455,7 +455,11 @@ foreach ($Customer in ($LatestCsvPerCustomer.Keys | Sort-Object)) {
         }
     }
     $CustomerTabs += '<button class="tablinks" onclick="openCustomer(event, ''' + $Customer + ''')">' + $Customer + ' (' + $RowCount + ')</button>'
-    $lastSeenText = ($filterDays -eq 0) ? 'Dit zijn alle machines die gevonden kunnen worden.' : "Deze machines zijn de laatste $filterDays dagen online geweest.";
+    if ($filterDays -eq 0) {
+        $lastSeenText = 'Dit zijn alle machines die gevonden kunnen worden.'
+    } else {
+        $lastSeenText = "Deze machines zijn de laatste $filterDays dagen online geweest."
+    }
     $CustomerTables += @"
     <div id="$Customer" class="tabcontent" style="display:none">
         <h2>Laatste overzicht voor $Customer ($($LatestDatePerCustomer[$Customer]))</h2>


### PR DESCRIPTION
Improve clarity in the assignment of the last seen text by using an if-else structure instead of a ternary operator.