### PR TITLE
Fix dark mode toggle icons to use FontAwesome for cross-browser compa…

### DIFF
--- a/get-windows-update-report.ps1
+++ b/get-windows-update-report.ps1
@@ -562,6 +562,7 @@ $Html = @"
     <title>Windows Update Overview</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css"/>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"/>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
     <script>
@@ -572,8 +573,14 @@ $Html = @"
         if (btn) {
             btn.addEventListener('click', function() {
                 document.body.classList.toggle('darkmode');
-                btn.textContent = document.body.classList.contains('darkmode') ? '☀️ Light mode' : '🌙 Dark mode';
+                if (document.body.classList.contains('darkmode')) {
+                    btn.innerHTML = '<i class="fa-solid fa-sun"></i> Light mode';
+                } else {
+                    btn.innerHTML = '<i class="fa-solid fa-moon"></i> Dark mode';
+                }
             });
+            // Set initial icon
+            btn.innerHTML = '<i class="fa-solid fa-moon"></i> Dark mode';
         }
     });
     </script>
@@ -606,7 +613,7 @@ $Html = @"
 </head>
 <body>
 <div class="container">
-    <h1>Windows Update Overview <button id="darkModeToggle" style="float:right;margin-left:20px;">🌙 Dark mode</button></h1>
+    <h1>Windows Update Overview <button id="darkModeToggle" style="float:right;margin-left:20px;"><i class="fa-solid fa-moon"></i> Dark mode</button></h1>
 
     <p>Laatst uitgevoerd op: $LastRunDate</p>
     <h2>Totale Count per dag per klant</h2>


### PR DESCRIPTION
This pull request enhances the user interface of the Windows Update Overview report by upgrading the dark mode toggle button to use Font Awesome icons, making the toggle more visually appealing and intuitive. The changes primarily affect the HTML and JavaScript responsible for rendering and handling the dark mode feature.

**UI/UX improvements:**

* Added a link to the Font Awesome stylesheet to enable icon usage in the report (`get-windows-update-report.ps1`).
* Updated the dark mode toggle button to display a moon or sun icon using Font Awesome, both on initial load and when toggling between modes (`get-windows-update-report.ps1`). [[1]](diffhunk://#diff-85f20a91d0c3da29186b724aac5d0c4e77b0307ad8a31f404e2e02cd629295d0L609-R616) [[2]](diffhunk://#diff-85f20a91d0c3da29186b724aac5d0c4e77b0307ad8a31f404e2e02cd629295d0L575-R583)