### PR TITLE
[FR] Default for day/night mode

### DIFF
--- a/CONFIG-UITLEG.md
+++ b/CONFIG-UITLEG.md
@@ -91,6 +91,25 @@ Deze filtering is zichtbaar in zowel de tabellen als de grafieken in het HTML-da
 - **Type**: String
 - **Beschrijving**: Paden voor de root en subfolders van back-ups. Je kunt deze aanpassen naar wens.
 
+### `theme`
+
+- **Type**: Object
+- **Beschrijving**: Instellingen voor het standaard dashboard-thema.
+
+#### `default`
+
+- **Type**: String
+- **Opties**: "dark", "light"
+- **Beschrijving**: Bepaalt of het dashboard standaard in donkere of lichte modus start. Je kunt altijd handmatig wisselen via de knop in het dashboard.
+
+**Voorbeeld:**
+
+```json
+"theme": {
+    "default": "dark"
+}
+```
+
 ## Voorbeeld Configuratie
 
 ```json
@@ -112,6 +131,9 @@ Deze filtering is zichtbaar in zowel de tabellen als de grafieken in het HTML-da
         "exportBackupSubfolder": "export_backup",
         "archiveBackupSubfolder": "archive_backup",
         "configBackupSubfolder": "config_backup"
+    },
+    "theme": {
+        "default": "dark"
     }
 }
 ```
@@ -125,3 +147,4 @@ Met deze instellingen:
 - Het HTML-rapport wordt automatisch geopend in de webbrowser
 - De rapportage wordt gefilterd op basis van het aantal dagen sinds een device voor het laatst gezien is (indien ingesteld)
 - Back-ups worden gemaakt van de exports, archief en configuratiebestanden volgens de opgegeven instellingen
+- Het dashboard start standaard in donkere modus (kan handmatig gewijzigd worden)

--- a/_config.json
+++ b/_config.json
@@ -16,5 +16,8 @@
         "exportBackupSubfolder": "export_backup",
         "archiveBackupSubfolder": "archive_backup",
         "configBackupSubfolder": "config_backup"
-    }
+    },
+    "theme": {
+        "default": "dark"
+}
 }

--- a/get-windows-update-report.ps1
+++ b/get-windows-update-report.ps1
@@ -567,20 +567,26 @@ $Html = @"
     <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
     <script>
     $DataTablesScript
-    // Dark mode toggle
+    // Dark mode toggle with manual config only
     document.addEventListener('DOMContentLoaded', function() {
+        var configThemeDefault = "$($config.theme.default)".toLowerCase();
         var btn = document.getElementById('darkModeToggle');
+        function setTheme(useDark) {
+            if (useDark) {
+                document.body.classList.add('darkmode');
+                if (btn) btn.innerHTML = '<i class="fa-solid fa-sun"></i> Light mode';
+            } else {
+                document.body.classList.remove('darkmode');
+                if (btn) btn.innerHTML = '<i class="fa-solid fa-moon"></i> Dark mode';
+            }
+        }
+        // Set initial theme and button state
+        setTheme(configThemeDefault === "dark");
         if (btn) {
             btn.addEventListener('click', function() {
-                document.body.classList.toggle('darkmode');
-                if (document.body.classList.contains('darkmode')) {
-                    btn.innerHTML = '<i class="fa-solid fa-sun"></i> Light mode';
-                } else {
-                    btn.innerHTML = '<i class="fa-solid fa-moon"></i> Dark mode';
-                }
+                var isDark = document.body.classList.contains('darkmode');
+                setTheme(!isDark);
             });
-            // Set initial icon
-            btn.innerHTML = '<i class="fa-solid fa-moon"></i> Dark mode';
         }
     });
     </script>

--- a/readme.md
+++ b/readme.md
@@ -209,6 +209,19 @@ In het `config.json` bestand kun je per back-up type instellen of deze actief is
 
 Back-ups worden opgeslagen in de opgegeven subfolders onder de root. Overtollige back-ups worden automatisch verwijderd.
 
+## Thema (dark/light mode)
+
+Het HTML-dashboard ondersteunt een dark/light modus. Je kunt de standaardmodus instellen via de configuratie:
+
+```json
+"theme": {
+    "default": "dark" // opties: "dark", "light"
+}
+```
+
+- **default**: Kies "dark" voor standaard donkere modus, of "light" voor standaard lichte modus.
+- Je kunt altijd handmatig wisselen via de knop rechtsboven in het dashboard.
+
 ## Dark mode toggle
 
 Het HTML-dashboard bevat een dark mode toggle-knop rechtsboven. Hiermee kun je eenvoudig wisselen tussen licht en donker thema. De knop gebruikt FontAwesome iconen (zon/maan) voor een consistente weergave in alle browsers.


### PR DESCRIPTION
This pull request introduces a configurable dashboard theme (dark/light mode) to the Windows Update report tool. Users can now set the default theme in the configuration, and the dashboard will start in the selected mode, with the option to switch manually via a toggle button. The documentation has been updated to explain the new theme setting.

**Theme configuration and dashboard behavior:**

* Added a new `theme` object to the configuration (`_config.json` and documented in `CONFIG-UITLEG.md` and `readme.md`), allowing users to set the default dashboard theme to "dark" or "light". [[1]](diffhunk://#diff-34ed1738d9c1253e89013a857b494c34b728c249d7eccff46d4a62a685e36740R94-R112) [[2]](diffhunk://#diff-fd660d6873efb5c6a91581ca2d615aa5194531140391cc13535b0f9ad584e70bR19-R21) [[3]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R212-R224)
* Updated the dashboard startup logic in `get-windows-update-report.ps1` to read the default theme from the configuration and apply it automatically. The toggle button now reflects the current mode, and users can manually switch themes.
* Documentation expanded to explain the theme configuration, including usage examples and the effect on dashboard startup. [[1]](diffhunk://#diff-34ed1738d9c1253e89013a857b494c34b728c249d7eccff46d4a62a685e36740R94-R112) [[2]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R212-R224)
* Example configuration and feature summary updated to include the new theme setting and its impact. [[1]](diffhunk://#diff-34ed1738d9c1253e89013a857b494c34b728c249d7eccff46d4a62a685e36740R134-R136) [[2]](diffhunk://#diff-34ed1738d9c1253e89013a857b494c34b728c249d7eccff46d4a62a685e36740R150)