### PR TITLE
Remove "github-actions" label from Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
-      - "github-actions"
     reviewers:
       - "MaartenSchmeitz"
 


### PR DESCRIPTION
This pull request makes a minor update to the Dependabot configuration by removing the `github-actions` label from the list of labels applied to dependency update pull requests.