### PR TITLE
Add timezone conversion functionality and update LastSeen timestamps …

### DIFF
--- a/_config.json
+++ b/_config.json
@@ -5,6 +5,7 @@
     "archiveDirectory": "archive",
     "autoOpenHtmlReport": true,
     "lastSeenDaysFilter": 0,
+    "timezoneOffsetHours": 2,
     "kbMapping": {
         "kbMappingUrl": "https://raw.githubusercontent.com/scns/Windows-Update-Report-MultiTenant/refs/heads/main/kb-mapping.json",
         "timeoutSeconds": 10,

--- a/get-windows-update-report.ps1
+++ b/get-windows-update-report.ps1
@@ -43,10 +43,67 @@ catch {
     exit 1
 }
 
+# Timezone conversie functie
+function Convert-UTCToLocalTime {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$UTCTimeString,
+        [Parameter(Mandatory=$false)]
+        [int]$OffsetHours = 0
+    )
+    
+    try {
+        # Controleer of de string al timezone info bevat
+        if ($UTCTimeString -match 'Z$' -or $UTCTimeString -match '[+-]\d{2}:\d{2}$') {
+            # Parse als UTC tijd met timezone info
+            $utcTime = [DateTime]::Parse($UTCTimeString).ToUniversalTime()
+        } else {
+            # Probeer verschillende DateTime formaten
+            $utcTime = $null
+            $formats = @(
+                "yyyy-MM-ddTHH:mm:ss.fffZ",
+                "yyyy-MM-ddTHH:mm:ssZ", 
+                "yyyy-MM-ddTHH:mm:ss",
+                "MM/dd/yyyy HH:mm:ss",
+                "dd/MM/yyyy HH:mm:ss"
+            )
+            
+            foreach ($format in $formats) {
+                try {
+                    $utcTime = [DateTime]::ParseExact($UTCTimeString, $format, $null)
+                    break
+                } catch {
+                    # Probeer volgende formaat
+                }
+            }
+            
+            # Als geen formaat werkt, probeer standaard parse
+            if (-not $utcTime) {
+                $utcTime = [DateTime]::Parse($UTCTimeString)
+            }
+        }
+        
+        # Voeg offset toe
+        $localTime = $utcTime.AddHours($OffsetHours)
+        
+        # Return formatted string
+        return $localTime.ToString("yyyy-MM-dd HH:mm:ss")
+    }
+    catch {
+        # Return original string als conversie faalt
+        Write-Verbose "Timezone conversie gefaald voor '$UTCTimeString': $($_.Exception.Message)"
+        return $UTCTimeString
+    }
+}
+
 # Globale cache voor KB mapping
 $Global:CachedKBMapping = $null
 $Global:KBMappingCacheTime = $null
 $Global:KBMappingCacheValidMinutes = 30  # Cache geldig voor 30 minuten
+
+# Timezone offset uit config (standaard 0 voor UTC)
+$TimezoneOffsetHours = if ($config.timezoneOffsetHours) { $config.timezoneOffsetHours } else { 0 }
+Write-Host "Timezone offset: UTC+$TimezoneOffsetHours uur" -ForegroundColor Cyan
 
 # Functie om KB mapping te laden en cachen
 function Get-CachedKBMapping {
@@ -687,7 +744,7 @@ foreach ($cred in $data.LoginCredentials) {
                     DeviceName = $_.DeviceName
                     MissingUpdates = @("Windows Update status: Controleer handmatig - Device niet in Intune beheer")
                     Count = 1  # Handmatige controle vereist = niet up-to-date
-                    LastSeen = $_.LastSeen
+                    LastSeen = Convert-UTCToLocalTime -UTCTimeString $_.LastSeen -OffsetHours $TimezoneOffsetHours
                     LoggedOnUsers = if ($_.LoggedOnUsers -is [System.Array]) { $_.LoggedOnUsers -join ', ' } else { $_.LoggedOnUsers }
                     OSPlatform = $_.OSPlatform
                     OSVersion = $_.OSVersion
@@ -812,7 +869,35 @@ foreach ($cred in $data.LoginCredentials) {
                     # Als geen specifieke problemen gevonden, bepaal status op basis van synchronisatie en OS versie
                     if ($MissingUpdates.Count -eq 0 -and $UpdateStatus -eq "Onbekend") {
                         $DaysSinceSync = if ($Device.lastSyncDateTime) {
-                            [Math]::Round((New-TimeSpan -Start ([DateTime]$Device.lastSyncDateTime) -End (Get-Date)).TotalDays)
+                            try {
+                                # Probeer verschillende DateTime formaten voor robuuste parsing
+                                $syncTime = $null
+                                $formats = @(
+                                    "yyyy-MM-ddTHH:mm:ss.fffZ",
+                                    "yyyy-MM-ddTHH:mm:ssZ", 
+                                    "yyyy-MM-ddTHH:mm:ss",
+                                    "MM/dd/yyyy HH:mm:ss",
+                                    "dd/MM/yyyy HH:mm:ss"
+                                )
+                                
+                                foreach ($format in $formats) {
+                                    try {
+                                        $syncTime = [DateTime]::ParseExact($Device.lastSyncDateTime, $format, $null)
+                                        break
+                                    } catch { }
+                                }
+                                
+                                if (-not $syncTime) {
+                                    $syncTime = [DateTime]::Parse($Device.lastSyncDateTime)
+                                }
+                                
+                                # Vergelijk met huidige tijd (beide in UTC als mogelijk)
+                                $now = if ($syncTime.Kind -eq 'Utc') { (Get-Date).ToUniversalTime() } else { Get-Date }
+                                [Math]::Round((New-TimeSpan -Start $syncTime -End $now).TotalDays)
+                            } catch {
+                                Write-Verbose "Kan lastSyncDateTime niet parsen voor $($Device.deviceName): $($Device.lastSyncDateTime)"
+                                999
+                            }
                         } else { 999 }
                         
                         # Controleer OS versie - voeg deze informatie toe voor transparantie
@@ -844,7 +929,7 @@ foreach ($cred in $data.LoginCredentials) {
                         MissingUpdates = $MissingUpdates
                         ActualMissingUpdates = $ActualMissingUpdates
                         Count = if ($UpdateStatus -in @("Up to date", "Waarschijnlijk up to date")) { 0 } else { 1 }
-                        LastSeen = $Device.lastSyncDateTime
+                        LastSeen = Convert-UTCToLocalTime -UTCTimeString $Device.lastSyncDateTime -OffsetHours $TimezoneOffsetHours
                         LoggedOnUsers = if ($Device.userPrincipalName) { $Device.userPrincipalName } else { "Geen gebruiker" }
                         OSPlatform = $Device.operatingSystem
                         OSVersion = $Device.osVersion
@@ -858,7 +943,7 @@ foreach ($cred in $data.LoginCredentials) {
                         DeviceName = $Device.deviceName
                         MissingUpdates = @("Error: Kan Windows Update status niet controleren")
                         Count = 1  # Error = niet up-to-date
-                        LastSeen = $Device.lastSyncDateTime
+                        LastSeen = Convert-UTCToLocalTime -UTCTimeString $Device.lastSyncDateTime -OffsetHours $TimezoneOffsetHours
                         LoggedOnUsers = if ($Device.userPrincipalName) { $Device.userPrincipalName } else { "Geen gebruiker" }
                         OSPlatform = $Device.operatingSystem
                         OSVersion = if ($Device.osVersion) { $Device.osVersion } else { "Onbekend" }
@@ -1452,7 +1537,7 @@ foreach ($Customer in ($LatestCsvPerCustomer.Keys | Sort-Object)) {
                     <th>KB Method</th>
                     <th>OS Version</th>
                     <th>Count</th>
-                    <th>LastSeen</th>
+                    <th>LastSeen (UTC+$TimezoneOffsetHours)</th>
                     <th>LoggedOnUsers</th>
                 </tr>
             </thead>


### PR DESCRIPTION
This pull request introduces support for timezone conversion in the Windows Update report, allowing timestamps to be displayed in a configurable local time instead of UTC. The main changes include adding a timezone offset setting to the configuration, implementing a robust PowerShell function for UTC-to-local time conversion, and updating all relevant report fields to use local time. Additionally, the HTML report now clearly indicates the timezone offset for the "LastSeen" column.

**Timezone support and conversion:**

* Added `timezoneOffsetHours` to `_config.json` to allow configuration of the desired timezone offset for reports.
* Implemented the `Convert-UTCToLocalTime` PowerShell function to reliably convert UTC timestamps to local time using the configured offset, with support for multiple date formats and error handling.
* Updated all usages of `LastSeen` in the report generation logic to use the new conversion function, ensuring timestamps reflect the local timezone. [[1]](diffhunk://#diff-85f20a91d0c3da29186b724aac5d0c4e77b0307ad8a31f404e2e02cd629295d0L690-R747) [[2]](diffhunk://#diff-85f20a91d0c3da29186b724aac5d0c4e77b0307ad8a31f404e2e02cd629295d0L847-R932) [[3]](diffhunk://#diff-85f20a91d0c3da29186b724aac5d0c4e77b0307ad8a31f404e2e02cd629295d0L861-R946)

**Report clarity improvements:**

* Changed the "LastSeen" column header in the HTML output to display the configured timezone offset, making it clear to users which timezone is being used.

**Robust date parsing:**

* Improved parsing of device sync times (`lastSyncDateTime`) to handle multiple date formats and fallback strategies, reducing errors in time calculations.