### PR TITLE
Refactor labeler configuration to use 'changed-files' structure for i…

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,51 +3,67 @@
 
 # KB Update related files
 kb-update:
-  - "kb-mapping.json"
-  - "KB-CACHING-INFO.md"
-  - "**/*kb*.json"
-  - "**/*knowledge*.md"
+  - changed-files:
+    - any-glob-to-any-file: 
+      - "kb-mapping.json"
+      - "KB-CACHING-INFO.md"
+      - "**/*kb*.json"
+      - "**/*knowledge*.md"
 
 # Documentation
 documentation:
-  - "*.md"
-  - "**/*.md"
-  - "docs/**/*"
-  - "README*"
+  - changed-files:
+    - any-glob-to-any-file:
+      - "*.md"
+      - "**/*.md"
+      - "docs/**/*"
+      - "README*"
 
 # Configuration files
 maintenance:
-  - "_config.json"
-  - "config.json"
-  - "_credentials.json"
-  - "credentials.json"
-  - "*.json"
+  - changed-files:
+    - any-glob-to-any-file:
+      - "_config.json"
+      - "config.json"
+      - "_credentials.json"
+      - "credentials.json"
+      - "*.json"
 
 # PowerShell scripts
 enhancement:
-  - "*.ps1"
-  - "*.psm1"
-  - "**/*.ps1"
+  - changed-files:
+    - any-glob-to-any-file:
+      - "*.ps1"
+      - "*.psm1"
+      - "**/*.ps1"
 
 # CI/CD workflows
 ci:
-  - ".github/workflows/**/*"
-  - ".github/**/*.yml"
-  - ".github/**/*.yaml"
+  - changed-files:
+    - any-glob-to-any-file:
+      - ".github/workflows/**/*"
+      - ".github/**/*.yml"
+      - ".github/**/*.yaml"
 
 # Dependencies
 dependencies:
-  - "package.json"
-  - "requirements.txt"
-  - "**/package*.json"
+  - changed-files:
+    - any-glob-to-any-file:
+      - "package.json"
+      - "requirements.txt"
+      - "**/package*.json"
 
 # Security related
 security:
-  - "SECURITY.md"
-  - "**/*security*"
+  - changed-files:
+    - any-glob-to-any-file:
+      - "SECURITY.md"
+      - "**/*security*"
 
 # Breaking changes (if certain files are modified)
 breaking-change:
-  - "config.json"
-  - "_config.json"
-  - "_credentials.json"
+  - changed-files:
+    - any-glob-to-any-file:
+      - "get-windows-update-report.ps1"
+      - "config.json"
+      - "_config.json"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -64,6 +64,5 @@ security:
 breaking-change:
   - changed-files:
     - any-glob-to-any-file:
-      - "get-windows-update-report.ps1"
-      - "config.json"
+      - "_credentials.json"
       - "_config.json"


### PR DESCRIPTION
This pull request updates the `.github/labeler.yml` configuration to improve how labels are automatically assigned to pull requests based on changed files. The changes standardize the labeler rules by making use of the `changed-files` and `any-glob-to-any-file` syntax, which increases accuracy and maintainability.