### PR TITLE
Ensure "in-progress" label is added only when not ready for review

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -31,6 +31,7 @@ jobs:
           numOfAssignee: 1
 
       - name: 🏷️ Add "in-progress" label to assigned items
+        if: github.event.action != 'ready_for_review'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Modify the workflow to add the "in-progress" label only if the item is not marked as ready for review.