### PR TITLE
feat(kb-mapping): add September 2025 Preview and Final Update entries

### DIFF
--- a/kb-mapping.json
+++ b/kb-mapping.json
@@ -43,7 +43,13 @@
             "kb": "KB5065522",
             "date": "2025-09",
             "releaseDate": "2025-09-09",
-            "description": "September 2025 Update"
+            "description": "September 2025 Preview Update"
+          },
+          "26100.6584": {
+            "kb": "KB5065426",
+            "date": "2025-09",
+            "releaseDate": "2025-09-09",
+            "description": "September 2025 Final Update"
           },
           "26100.4946": {
             "kb": "KB5063878",


### PR DESCRIPTION
This pull request updates the Windows update mapping in `kb-mapping.json` to clarify release descriptions and add a new entry for September 2025. The most important changes are:

**Release description updates:**

* Changed the description for version `26100.6522` from "September 2025 Update" to "September 2025 Preview Update" to clarify its status.

**New release entry:**

* Added a new entry for version `26100.6584` with KB number `KB5065426`, release date `2025-09-09`, and description "September 2025 Final Update".