### PR TITLE
Remove KB-Method from table

### DIFF
--- a/get-windows-update-report.ps1
+++ b/get-windows-update-report.ps1
@@ -1344,7 +1344,6 @@ foreach ($cred in $data.LoginCredentials) {
             "Update Status" = if ($_.UpdateStatus) { $_.UpdateStatus } else { "Onbekend" }
             "Compliance Status" = if ($_.ComplianceStatus) { $_.ComplianceStatus } else { "Onbekend" }
             "Missing Updates" = $MissingUpdatesDisplay
-            "KB Method" = if ($_.KBMethod) { $_.KBMethod } else { "N/A" }
             "OS Version" = if ($_.OSVersion) { $_.OSVersion } else { "Onbekend" }
             "Count" = if ($_.Count -gt 0) { $_.Count } else { 0 }
             "LastSeen" = $_.LastSeen


### PR DESCRIPTION
This pull request makes a minor change to the Windows update report script by removing the "KB Method" column from the output.

* Removed the "KB Method" field from the report output in the `foreach ($cred in $data.LoginCredentials) {` loop in `get-windows-update-report.ps1`.