### PR TITLE
refactor: remove unnecessary build number extraction for missing updates

### DIFF
--- a/get-windows-update-report.ps1
+++ b/get-windows-update-report.ps1
@@ -1238,19 +1238,10 @@ foreach ($cred in $data.LoginCredentials) {
                         if ($currentBuild -match '^\d+$' -and $latestBuild -match '^\d+$') {
                             $buildDifference = [int]$latestBuild - [int]$currentBuild
                             if ($buildDifference -gt 0) {
-                                # Bepaal volledige build nummers voor Windows versie detectie
-                                $fullCurrentBuild = $result.OSVersion -replace '^.*\.(\d+\.\d+)$', '$1'
-                                $fullLatestBuild = $LatestOSVersion -replace '^.*\.(\d+\.\d+)$', '$1'
-                                
-                                # Extract major build (bijv. 26100 uit 26100.4652)
-                                $majorCurrentBuild = if ($fullCurrentBuild -match '^(\d+)\.') { $matches[1] } else { $currentBuild }
-                                $majorLatestBuild = if ($fullLatestBuild -match '^(\d+)\.') { $matches[1] } else { $latestBuild }
-                                
                                 # Gebruik KB database om missing updates te bepalen
                                 Write-Verbose "Looking up KB information for OS version: $($result.OSVersion)"
                                 $kbMappingCache = $Global:CachedKBMapping
                                 $missingKBsFromDB = Get-MissingUpdatesFromKBDatabase -CurrentOSVersion $result.OSVersion -KBMappingCache $kbMappingCache
-                                
                                 if ($missingKBsFromDB.Count -gt 0) {
                                     $newResult.ActualMissingUpdates += $missingKBsFromDB
                                     $newResult.KBMethod = "KB Database"


### PR DESCRIPTION
This pull request simplifies the logic for determining missing Windows updates by removing unnecessary extraction of full and major build numbers. The code now directly compares build numbers and uses the KB database for missing updates, making the process more straightforward and maintainable.

Improvements to Windows update detection logic:

* Removed extraction of full and major build numbers from `OSVersion` and `LatestOSVersion`, reducing complexity in the build comparison process.
* The script now relies solely on the KB database lookup for determining missing updates when a build difference is detected.