### PR TITLE
refactor: reorganize KB Database Update category and add "in-progress…

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -32,9 +32,6 @@ autolabeler:
       - '/new/i'
 
 categories:
-  - title: "🗂️ KB Database Update"
-    labels:
-    - "kb-update"
   - title: "🚨 Major Release 🚨"
     labels:
       - "major-change"
@@ -44,6 +41,9 @@ categories:
   - title: "✨ New features"
     labels:
       - "new-feature"
+  - title: "🗂️ KB Database Update"
+    labels:
+    - "kb-update"
   - title: "🐛 Bug fixes"
     labels:
       - "bugfix"

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -30,17 +30,4 @@ jobs:
           assignees: scns
           numOfAssignee: 1
 
-      - name: 🏷️ Add "in-progress" label to assigned items
-        if: github.event.action != 'ready_for_review'
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const issueNumber = context.payload.pull_request?.number || context.payload.issue?.number;
-            if (issueNumber) {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                labels: ['in-progress']
-              });
-            }
+    


### PR DESCRIPTION
This pull request makes minor updates to our GitHub workflow and release categorization configuration files. The most important changes are the adjustment of release categories and the removal of an automatic labeling step in the workflow.

Release categorization updates:

* Moved the "🗂️ KB Database Update" category from the top of the list to appear after "✨ New features" in `.github/release-drafter.yml`, ensuring better organization and visibility of release notes. [[1]](diffhunk://#diff-101bec72d0f1f84e7290d113531bbd8c6aa355cdc9f456df255544bc0a2da0eaL35-L37) [[2]](diffhunk://#diff-101bec72d0f1f84e7290d113531bbd8c6aa355cdc9f456df255544bc0a2da0eaR44-R46)

Workflow simplification:

* Removed the workflow step that automatically added the "in-progress" label to assigned items in `.github/workflows/auto-assign.yml`, streamlining the assignment process.