### PR TITLE
chore: update version information to 3.0.0 and last edit date in scripts

### DIFF
--- a/get-windows-update-report.ps1
+++ b/get-windows-update-report.ps1
@@ -22,15 +22,15 @@ De resultaten worden geëxporteerd naar CSV-bestanden en een HTML-dashboard met 
 Maarten Schmeitz (info@maarten-schmeitz.nl  | https://www.mrtn.blog)
 
 .LASTEDIT
-2025-08-13
+2025-09-11
 
 .VERSIE
-3.0
+3.0.0
 #>
 
 #Versie-informatie
-    $ProjectVersion = "3.0"
-    $LastEditDate = "2025-08-13"
+    $ProjectVersion = "3.0.0"
+    $LastEditDate = "2025-09-11"
 
 # Import configuratie
     try {

--- a/readme.md
+++ b/readme.md
@@ -838,7 +838,7 @@ Controleer in Azure Portal of je App Registration deze permissies heeft:
 
 ---
 
-© 2025 l 22/08/2025 by Maarten Schmeitz
+© 2025 by Maarten Schmeitz
 
 [commits-shield]: https://img.shields.io/github/commit-activity/m/scns/Windows-Update-Report-MultiTenant.svg
 [commits]: https://github.com/scns/Windows-Update-Report-MultiTenant/commits/main


### PR DESCRIPTION
This pull request makes minor updates to versioning information and copyright statements in the project documentation and script headers.

* Versioning updates:
  * Updated the project version from `3.0` to `3.0.0` and the last edit date from `2025-08-13` to `2025-09-11` in `get-windows-update-report.ps1`.

* Documentation updates:
  * Removed the date from the copyright statement in `readme.md`.