### PR TITLE
chore: update documentation and version information to v3.0

### DIFF
--- a/CONFIG-UITLEG.md
+++ b/CONFIG-UITLEG.md
@@ -1,4 +1,4 @@
-# Configuratie Uitleg - config.json
+# Configuratie Uitleg - config.json v3.0
 
 Dit bestand legt uit wat elke instelling in `config.json` doet voor versie 3.0.
 

--- a/CREDENTIALS-SETUP.md
+++ b/CREDENTIALS-SETUP.md
@@ -1,4 +1,4 @@
-# Credentials Setup Guide
+# Credentials Setup Guide v3.0
 
 Deze handleiding legt uit hoe je de credentials correct instelt voor het Windows Update Report MultiTenant script.
 

--- a/get-windows-update-report.ps1
+++ b/get-windows-update-report.ps1
@@ -30,7 +30,7 @@ Maarten Schmeitz (info@maarten-schmeitz.nl  | https://www.mrtn.blog)
 
 #Versie-informatie
     $ProjectVersion = "3.0.0"
-    $LastEditDate = "2025-09-11"
+    $LastEditDate = "2025-09-15"
 
 # Import configuratie
     try {

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Windows Update Report MultiTenant
+# Windows Update Report MultiTenant v3.0
 
 | Repository Status | Windows Update Report |
 | :--- | :--- |


### PR DESCRIPTION
This pull request updates documentation and versioning details to reflect the release of version 3.0 of the Windows Update Report MultiTenant project. The most important changes are grouped below by theme:

Documentation updates:

* Updated `readme.md` to indicate version 3.0 in the project title.
* Updated `CONFIG-UITLEG.md` to specify that the configuration explanation is for version 3.0.
* Updated `CREDENTIALS-SETUP.md` to clarify that the credentials setup guide applies to version 3.0.

Versioning:

* Updated the `$LastEditDate` in `get-windows-update-report.ps1` to "2025-09-15" and confirmed the `$ProjectVersion` is "3.0.0".